### PR TITLE
doc: add namespace to fix some 404s in doc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,15 @@
 /**
  * @namespace google.cloud.tasks.v2beta3
  */
+/**
+ * @namespace google.protobuf
+ */
+/**
+ * @namespace google.rpc
+ */
+/**
+ * @namespace google.type
+ */
 
 'use strict';
 


### PR DESCRIPTION
For example, `Timestamp` in
https://cloud-dot-devsite.googleplex.com/nodejs/docs/reference/tasks/0.2.x/google.cloud.tasks.v2beta3#.Attempt
links to a 404 page.