### PR TITLE
feat: restoring v2beta2 by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ const gapic = Object.freeze({
  * @property {constructor} CloudTasksClient
  *   Reference to {@link v2beta3.CloudTasksClient}
  */
-module.exports = gapic.v2beta3;
+module.exports = gapic.v2beta2;
 
 /**
  * @type {object}


### PR DESCRIPTION
Fixes samples tests failure since `samples/tasks.js` is not compatible with `v2beta3`.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
