### PR TITLE
refactor(samples): convert sample tests from ava to mocha

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
+    "mocha": "^5.2.0",
     "proxyquire": "^2.0.1",
     "sinon": "^7.0.0"
   },

--- a/samples/package.json
+++ b/samples/package.json
@@ -9,7 +9,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "unit-test": "ava --verbose system-test/*.test.js",
+    "unit-test": "mocha system-test/*.test.js --timeout=600000",
     "system-test": "repo-tools test app --config package.json --config-key cloud-repo-tools",
     "test": "npm run unit-test && npm run system-test"
   },
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "^0.25.0",
     "proxyquire": "^2.0.1",
     "sinon": "^7.0.0"
   },

--- a/samples/system-test/.eslintrc.yml
+++ b/samples/system-test/.eslintrc.yml
@@ -1,5 +1,6 @@
 ---
+env:
+  mocha: true
 rules:
   node/no-unpublished-require: off
-  node/no-unsupported-features: off
   no-empty: off

--- a/samples/system-test/createTask.test.js
+++ b/samples/system-test/createTask.test.js
@@ -15,28 +15,28 @@
 
 'use strict';
 
-const path = require(`path`);
-const test = require(`ava`);
-const tools = require(`@google-cloud/nodejs-repo-tools`);
+const path = require('path');
+const assert = require('assert');
+const tools = require('@google-cloud/nodejs-repo-tools');
 
-const {runAsync} = require(`@google-cloud/nodejs-repo-tools`);
+const {runAsync} = require('@google-cloud/nodejs-repo-tools');
 
 const PROJECT_ID = process.env.GCLOUD_PROJECT;
 const QUEUE = process.env.QUEUE_ID || 'my-appengine-queue';
-const cmd = `node createTask.js`;
-const cwd = path.join(__dirname, `..`);
+const cmd = 'node createTask.js';
+const cwd = path.join(__dirname, '..');
 
-test.before(t => {
+before(() => {
   if (!QUEUE) {
-    t.fail(`You must set the QUEUE_ID environment variable!`);
+    assert.fail('You must set the QUEUE_ID environment variable!');
   }
+  tools.checkCredentials();
 });
-test.before(tools.checkCredentials);
 
-test.serial(`should create a task`, async t => {
+it('should create a task', async () => {
   const output = await runAsync(
     `${cmd} --project=${PROJECT_ID} --location=us-central1 --queue=${QUEUE}`,
     cwd
   );
-  t.true(output.includes('Created task'));
+  assert.strictEqual(output.includes('Created task'), true);
 });


### PR DESCRIPTION
Fixes convert all sample tests from ava to mocha [#2865](https://github.com/googleapis/google-cloud-node/issues/2865) (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
