### PR TITLE
fix: use compatible version of google-gax

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "google-gax": "^1.6.2"
+    "google-gax": "^1.6.3"
   },
   "devDependencies": {
     "codecov": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "predocs-test": "npm run docs"
   },
   "dependencies": {
-    "google-gax": "^1.0.0"
+    "google-gax": "^1.6.2"
   },
   "devDependencies": {
     "codecov": "^3.0.2",


### PR DESCRIPTION
Starting from google-gax v1.2.0, it's OK to pass just one filename to `loadProtos`.
Many users report issues when the newer client library still uses older version of
`google-gax`, passing one `filename` parameter to an older `loadProtos` that still
expects to see two parameters, causing weird error message:

```
TypeError: Cannot read property 'length' of undefined
    at Root.load (/srv/node_modules/protobufjs/src/root.js:192:44)
    at Root.loadSync (/srv/node_modules/protobufjs/src/root.js:235:17)
    at Object.loadSync (/srv/node_modules/@grpc/proto-loader/build/src/index.js:230:27)
    at GrpcClient.loadFromProto (/srv/node_modules/google-gax/build/src/grpc.js:118:44)
    at GrpcClient.loadProto (/srv/node_modules/google-gax/build/src/grpc.js:145:21)
```

One other important change is the set of correct headers for both gRPC and fallback 
scenarios.

Also, the newer `google-gax` pulls in the latest `@grpc/grpc-js` v0.6.3 which resolves
some of the issues with connections.

This set of auto-PRs updates the `google-gax` to the latest version 1.6.3.