### PR TITLE
feat!: promotes v2beta3 to default client, adding support for HTTP targets

### DIFF
--- a/samples/createHttpTask.js
+++ b/samples/createHttpTask.js
@@ -33,10 +33,10 @@ async function createHttpTask(
 ) {
   // [START cloud_tasks_create_http_task]
   // Imports the Google Cloud Tasks library.
-  const {v2beta3} = require('@google-cloud/tasks');
+  const {CloudTasksClient} = require('@google-cloud/tasks');
 
   // Instantiates a client.
-  const client = new v2beta3.CloudTasksClient();
+  const client = new CloudTasksClient();
 
   // TODO(developer): Uncomment these lines and replace with your values.
   // const project = 'my-project-id';

--- a/samples/createHttpTaskWithToken.js
+++ b/samples/createHttpTaskWithToken.js
@@ -34,10 +34,10 @@ async function createHttpTaskWithToken(
 ) {
   // [START cloud_tasks_create_http_task_with_token]
   // Imports the Google Cloud Tasks library.
-  const {v2beta3} = require('@google-cloud/tasks');
+  const {CloudTasksClient} = require('@google-cloud/tasks');
 
   // Instantiates a client.
-  const client = new v2beta3.CloudTasksClient();
+  const client = new CloudTasksClient();
 
   // TODO(developer): Uncomment these lines and replace with your values.
   // const project = 'my-project-id';

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ const gapic = Object.freeze({
  * @property {constructor} CloudTasksClient
  *   Reference to {@link v2beta3.CloudTasksClient}
  */
-module.exports = gapic.v2;
+module.exports = gapic.v2beta3;
 
 /**
  * @type {object}


### PR DESCRIPTION
BREAKING CHANGE: v2beta3 is now the default API surface, rather than v2.